### PR TITLE
Do not start a kernel by default

### DIFF
--- a/jupyter-config/labconfig/page_config.d/00-xtralab.json
+++ b/jupyter-config/labconfig/page_config.d/00-xtralab.json
@@ -1,4 +1,5 @@
 {
+  "notebookStartsKernel": false,
   "disabledExtensions": {
     "@jupyterlab/application-extension:logo": true,
     "@jupyterlab/application-extension:property-inspector": true,


### PR DESCRIPTION
Easier to work with notebooks as scratchpads.